### PR TITLE
Explicit count modifiers

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -524,7 +524,7 @@
         'name': 'string.quoted.single.js'
         'patterns': [
           {
-            'match': '\\\\(x\\h{2}|[0-2][0-7]{,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)'
+            'match': '\\\\(x\\h{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)'
             'name': 'constant.character.escape.js'
           }
         ]
@@ -541,7 +541,7 @@
         'name': 'string.quoted.double.js'
         'patterns': [
           {
-            'match': '\\\\(x\\h{2}|[0-2][0-7]{,2}|3[0-6][0-7]|37[0-7]?|[4-7][0-7]?|.)'
+            'match': '\\\\(x\\h{2}|[0-2][0-7]{0,2}|3[0-6][0-7]|37[0-7]?|[4-7][0-7]?|.)'
             'name': 'constant.character.escape.js'
           }
         ]
@@ -558,7 +558,7 @@
         'name': 'string.quoted.template.js'
         'patterns': [
           {
-            'match': '\\\\(x\\h{2}|[0-2][0-7]{,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)'
+            'match': '\\\\(x\\h{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)'
             'name': 'constant.character.escape.js'
           }
           {


### PR DESCRIPTION
The construction `{,2}` in regular expressions is only supported by Oniguruma (which is used by Atom). This Atom bundle is used to highlight JavaScript code on GitHub. However, GitHub is using a [PCRE-based engine](https://github.com/vmg/pcre) for regexes and thus, the following code gets incorrectly highlighted.
```javascript
addLinter("E014", function lintColParentsAreRowsOrFormGroups($, reporter) {
        var selector = COL_CLASSES.map(function (colClass) {
            return '*:not(.row):not(.form-group)>' + colClass + ':not(col):not(th):not(td)';
        }).join(',');
        var colsOutsideRowsAndFormGroups = $(selector);
        if (colsOutsideRowsAndFormGroups.length) {
            reporter("Columns (`.col-*-*`) can only be children of `.row`s or `.form-group`s", colsOutsideRowsAndFormGroups);
        }
    });
```

This pull request fixes that by using an explicit count modifier in the regex.
Fixes #142.
